### PR TITLE
Base64 payload as method 'strip_tags' modifies HTML tags in payload.

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -47,7 +47,7 @@ class Browser extends DuskBrowser
      *
      * @param  string   $facade
      * @param  string   $fake
-     * @return NoelDeMartin\LaravelDusk\Browser
+     * @return \NoelDeMartin\LaravelDusk\Browser
      */
     public function registerFake(string $facade, $fake)
     {

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -114,7 +114,7 @@ abstract class Driver
      */
     public function serialize(string $facade)
     {
-        return serialize($this->mocks[$facade]);
+        return base64_encode(serialize($this->mocks[$facade]));
     }
 
     /**
@@ -125,7 +125,7 @@ abstract class Driver
      */
     public function unserialize(string $serializedMock)
     {
-        return unserialize($serializedMock);
+        return unserialize(base64_decode($serializedMock));
     }
 
     /**

--- a/src/MockingProxy.php
+++ b/src/MockingProxy.php
@@ -64,9 +64,7 @@ class MockingProxy
             '/_dusk-mocking/serialize?facade='.urlencode($this->facade)
         );
 
-        $serializedMock = json_decode(
-            strip_tags($response->driver->getPageSource())
-        );
+        $serializedMock = strip_tags($response->driver->getPageSource());
 
         return is_null($serializedMock)
             ? null


### PR DESCRIPTION
In fact i had this payload: `.....{s:12:"restrictions";a:3:{s:9:"SHOP_FUEL";s:18:"Einkaufen & Tanken";s:4:"FUEL";s:6:"Tanken";s:4:"WASH";s:7:"Waschen";}........`

Due to the strip_tags methods the payload got modified like this: `.....{s:12:"restrictions";a:3:{s:9:"SHOP_FUEL";s:18:"Einkaufen &amp; Tanken";s:4:"FUEL";s:6:"Tanken";s:4:"WASH";s:7:"Waschen";}........`

which causes the unserialize to fail because the given length of `s:18:"Einkaufen & Tanken"` is no longer valid with `s:18:"Einkaufen &amp; Tanken"`