### PR TITLE
Javascript request does not respect the base url of the application

### DIFF
--- a/src/Browser.php
+++ b/src/Browser.php
@@ -119,9 +119,9 @@ class Browser extends DuskBrowser
     {
         switch ($method) {
             case 'GET':
-                return 'request.open("GET", "'.$url.'?'.http_build_query($params).'", true);';
+                return 'request.open("GET", "'. rtrim(self::$baseUrl, '/') . $url.'?'.http_build_query($params).'", true);';
             case 'POST':
-                return 'request.open("POST", "'.$url.'", true);'.
+                return 'request.open("POST", "'. rtrim(self::$baseUrl, '/') . $url.'", true);'.
                     'request.setRequestHeader("Content-Type", "application/x-www-form-urlencoded");';
         }
     }
@@ -132,7 +132,7 @@ class Browser extends DuskBrowser
             case 'GET':
                 return 'request.send();';
             case 'POST':
-                $token = $this->visit(URL::to('/_dusk-mocking/csrf_token'))->driver->getPageSource();
+                $token = $this->visit(URL::to(rtrim(self::$baseUrl, '/') . '/_dusk-mocking/csrf_token'))->driver->getPageSource();
                 $token = json_decode(strip_tags($token));
 
                 return 'request.send("'.http_build_query(array_merge($params, ['_token' => $token])).'");';


### PR DESCRIPTION
The latest changes has broken my working tests. After some investigation, i found out, that your javascript request does not respect the configured base url of the application. This is not critical if you have a single application configured as this will response on localhost request. In fact if you have multiple applications, you want the test to request the correct domain configured in your .env file.