### PR TITLE
Fixes a tiny issue with MockingServiceProvider.php

### DIFF
--- a/src/MockingServiceProvider.php
+++ b/src/MockingServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace NoelDeMartin\LaravelDusk;
 
+use Exception;
+
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use NoelDeMartin\LaravelDusk\Http\Middleware\SaveMocking;


### PR DESCRIPTION
I stumbled upon this when building with a bitbucket pipeline that didn’t have an environment configured and thus defaulted to "production.”

Without this line it fails like so:
```
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

In MockingServiceProvider.php line 52:

  Class 'NoelDeMartin\LaravelDusk\Exception' not found
```

with the patch:
```
> Illuminate\Foundation\ComposerScripts::postAutoloadDump
> @php artisan package:discover --ansi

In MockingServiceProvider.php line 54:

  It is unsafe to run Dusk in production.
```

which, I believe, is the desired result. 😄 
