### PR TITLE
Moving pushMiddlewareToGroup to boot method in service provider

### DIFF
--- a/src/MockingServiceProvider.php
+++ b/src/MockingServiceProvider.php
@@ -40,6 +40,13 @@ class MockingServiceProvider extends ServiceProvider
                     'uses' => 'MockingController@serialize',
                 ]);
             });
+        
+        if (! $this->app->runningInConsole()) {
+            foreach (Route::getMiddlewareGroups() as $group => $middlewares) {
+                Route::pushMiddlewareToGroup($group, StartMocking::class);
+                Route::pushMiddlewareToGroup($group, SaveMocking::class);
+            }
+        }
     }
 
     /**
@@ -57,12 +64,5 @@ class MockingServiceProvider extends ServiceProvider
         $this->app->singleton('dusk-mocking', function ($app) {
             return new MockingManager($app);
         });
-
-        if (! $this->app->runningInConsole()) {
-            foreach (Route::getMiddlewareGroups() as $group => $middlewares) {
-                Route::pushMiddlewareToGroup($group, StartMocking::class);
-                Route::pushMiddlewareToGroup($group, SaveMocking::class);
-            }
-        }
     }
 }


### PR DESCRIPTION
Hello,

with the newer laravel versions, using pushMiddlewareToGroup in register method is not supported anymore :

https://github.com/laravel/framework/issues/36604

this PR moves the pushMiddlewareToGroup calls to boot() method of the service provider.

thanks !