### PR TITLE
Add HTTP Client fake

### DIFF
--- a/src/Fakes/HttpFake.php
+++ b/src/Fakes/HttpFake.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace NoelDeMartin\LaravelDusk\Fakes;
+
+use Illuminate\Http\Client\Factory;
+
+class HttpFake extends Factory
+{
+    protected $config = [];
+
+    public function __construct(mixed $config = null)
+    {
+        $this->config = json_decode(json_encode($config), true);
+
+        parent::__construct(null);
+
+        if (! empty($this->config)) {
+            parent::fake($this->config);
+        }
+    }
+
+    public function __sleep() : array
+    {
+        return [
+            'recording',
+            'recorded',
+            'preventStrayRequests',
+            'allowedStrayRequestUrls',
+            'config',
+        ];
+    }
+
+    public function __wakeup() : void
+    {
+        $this->stubCallbacks = collect();
+
+        if (! empty($this->config)) {
+            parent::fake($this->config);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a minimal fake for the Http Client so that you can mock outbound API requests and the responses that they should return.

Example:

```php
use Illuminate\Support\Facades\Http;
use NoelDeMartin\LaravelDusk\Fakes\HttpFake;

Mocking::registerFake(Http::class, HttpFake::class);

$browser->fake(Http::class, [
    'https://google.com' => 200,
    'https://api.stripe.com/v1/subscriptions' => [
        'id'     => 'sub_1',
        'status' => 'active',
    ],
]);
```